### PR TITLE
Removed line break

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,5 +77,4 @@ We've figured out how to construct a solid structure for the HTML document. Now,
 as you pick up new HTML tags, you'll be able to add more elements to build out
 the rest of the page.
 
-[help]: http://help.learn.co/the-learn-ide/common-ide-questions/viewing-
-html-pages-in-the-learn-ide
+[help]: http://help.learn.co/the-learn-ide/common-ide-questions/viewing-html-pages-in-the-learn-ide


### PR DESCRIPTION
Link break in help link was causing broken link & leaving stray words at bottom of file.

Fixes : https://github.com/learn-co-curriculum/well-formed-html-document-lab/issues/9